### PR TITLE
Implement std::ops

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,5 +2,5 @@
 pub enum Error {
     OutOfRange,
     ParseInt,
-    InvalidString
+    InvalidString,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,13 +99,13 @@ macro_rules! derive_trait_for_type {
     };
 }
 
-macro_rules! add_mul_impl {
+macro_rules! add_mul_int_impl {
      ($($t:ty)+) => ($(
          derive_trait_for_type! { impl Mul with $t, mul }
      )+)
 }
 
-macro_rules! add_div_impl {
+macro_rules! add_div_int_impl {
      ($($t:ty)+) => ($(
          derive_trait_for_type! { impl Div with $t, div }
      )+)
@@ -113,14 +113,14 @@ macro_rules! add_div_impl {
 
 derive_trait_from_inner!(impl Add, add);
 derive_trait_from_inner!(impl Sub, sub);
-add_mul_impl! { i64 i32 i16 i8 u32 u16 u8 }
-add_div_impl! { i64 i32 i16 i8 u32 u16 u8 }
+add_mul_int_impl! { i64 i32 i16 i8 u32 u16 u8 }
+add_div_int_impl! { i64 i32 i16 i8 u32 u16 u8 }
 
 #[cfg(test)]
 mod tests {
     use crate::Money;
 
-    macro_rules! gen_mul_tests {
+    macro_rules! gen_mul_int_tests {
         ($t:ty, $success:ident, $of_max:ident, $of_min:ident) => {
             #[test]
             fn $success() {
@@ -143,7 +143,7 @@ mod tests {
         };
     }
 
-    macro_rules! gen_div_tests {
+    macro_rules! gen_div_int_tests {
         ($t:ty, $success:ident, $truncates:ident) => {
             #[test]
             fn $success() {
@@ -157,92 +157,92 @@ mod tests {
         };
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         i64,
         test_mul_success_i64,
         test_mul_fail_overflow_max_i64,
         test_mul_fail_overflow_min_i64
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         i32,
         test_mul_success_i32,
         test_mul_fail_overflow_max_i32,
         test_mul_fail_overflow_min_i32
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         i16,
         test_mul_success_i16,
         test_mul_fail_overflow_max_i16,
         test_mul_fail_overflow_min_i16
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         i8,
         test_mul_success_i8,
         test_mul_fail_overflow_max_i8,
         test_mul_fail_overflow_min_i8
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         u32,
         test_mul_success_u32,
         test_mul_fail_overflow_max_u32,
         test_mul_fail_overflow_min_u32
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         u16,
         test_mul_success_u16,
         test_mul_fail_overflow_max_u16,
         test_mul_fail_overflow_min_u16
     }
 
-    gen_mul_tests! {
+    gen_mul_int_tests! {
         u8,
         test_mul_success_u8,
         test_mul_fail_overflow_max_u8,
         test_mul_fail_overflow_min_u8
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         i64,
         test_div_success_i64,
         test_div_truncates_i64
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         i32,
         test_div_success_i32,
         test_div_truncates_i32
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         i16,
         test_div_success_i16,
         test_div_truncates_i16
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         i8,
         test_div_success_i8,
         test_div_truncates_i8
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         u32,
         test_div_success_u32,
         test_div_truncates_u32
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         u16,
         test_div_success_u16,
         test_div_truncates_u16
     }
 
-    gen_div_tests! {
+    gen_div_int_tests! {
         u8,
         test_div_success_u8,
         test_div_truncates_u8

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 use std::{fmt, str};
 
-mod parser;
 mod error;
+mod parser;
 
 use error::Error;
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Mul, Sub};
 
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Money(Inner);
@@ -14,11 +14,11 @@ impl Money {
     pub const MIN_INNER: Inner = -9223372036854775808;
     pub const MAX_INNER: Inner = 9223372036854775807;
 
-    pub const fn min() -> Money  {
+    pub const fn min() -> Money {
         Money(Money::MIN_INNER)
     }
 
-    pub const fn max() -> Money  {
+    pub const fn max() -> Money {
         Money(Money::MAX_INNER)
     }
 
@@ -31,7 +31,7 @@ impl Money {
     }
 
     fn dollars(&self) -> String {
-        format!("{}", self.0 /100)
+        format!("{}", self.0 / 100)
     }
 
     fn cents(&self) -> String {
@@ -77,21 +77,136 @@ macro_rules! derive_trait_from_inner {
         impl $imp for Money {
             type Output = Self;
 
-            // TODO: should this return a Result and do checked_add instead of panic?
             fn $method(self, rhs: Money) -> Self::Output {
                 Money(self.inner().$method(rhs.inner()))
             }
         }
-    }
+    };
+}
+
+macro_rules! derive_trait_for_type {
+    (impl $imp:ident with $t:ty, $method:ident) => {
+        impl $imp<$t> for Money
+        where
+            $t: Into<i64>,
+        {
+            type Output = Self;
+
+            fn $method(self, rhs: $t) -> Self::Output {
+                Money(self.inner().$method(rhs as i64))
+            }
+        }
+    };
+}
+
+macro_rules! add_mul_impl {
+     ($($t:ty)+) => ($(
+         derive_trait_for_type! { impl Mul with $t, mul }
+     )+)
 }
 
 derive_trait_from_inner!(impl Add, add);
 derive_trait_from_inner!(impl Sub, sub);
-derive_trait_from_inner!(impl Mul, mul);
+add_mul_impl! { i64 i32 i16 i8 u32 u16 u8 }
 
 #[cfg(test)]
 mod tests {
     use crate::Money;
+
+    macro_rules! gen_mul_tests {
+        ($t:ty, $success:ident, $of_max:ident, $of_min:ident) => {
+            #[test]
+            fn $success() {
+                assert_eq!(Money(7) * 3 as $t, Money(21))
+            }
+
+            #[test]
+            #[should_panic]
+            #[allow(unused_must_use)]
+            fn $of_max() {
+                Money::max() * 100 as $t;
+            }
+
+            #[test]
+            #[should_panic]
+            #[allow(unused_must_use)]
+            fn $of_min() {
+                Money::min() * 100 as $t;
+            }
+        };
+    }
+
+    gen_mul_tests! {
+        i64,
+        test_mul_success_i64,
+        test_mul_fail_overflow_max_i64,
+        test_mul_fail_overflow_min_i64
+    }
+
+    gen_mul_tests! {
+        i32,
+        test_mul_success_i32,
+        test_mul_fail_overflow_max_i32,
+        test_mul_fail_overflow_min_i32
+    }
+
+    gen_mul_tests! {
+        i16,
+        test_mul_success_i16,
+        test_mul_fail_overflow_max_i16,
+        test_mul_fail_overflow_min_i16
+    }
+
+    gen_mul_tests! {
+        i8,
+        test_mul_success_i8,
+        test_mul_fail_overflow_max_i8,
+        test_mul_fail_overflow_min_i8
+    }
+
+    gen_mul_tests! {
+        u32,
+        test_mul_success_u32,
+        test_mul_fail_overflow_max_u32,
+        test_mul_fail_overflow_min_u32
+    }
+
+    gen_mul_tests! {
+        u16,
+        test_mul_success_u16,
+        test_mul_fail_overflow_max_u16,
+        test_mul_fail_overflow_min_u16
+    }
+
+    gen_mul_tests! {
+        u8,
+        test_mul_success_u8,
+        test_mul_fail_overflow_max_u8,
+        test_mul_fail_overflow_min_u8
+    }
+
+    // macro_rules! test_mul_for_type {
+    //     ($t:ty $success:expr $overflow_max:expr $overflow_min:) => {
+    //         #[test]
+    //         fn test_multiplication_i32_success() {
+    //             assert_eq!(Money(7) * 3 as $t, Money(21))
+    //         }
+    //
+    //         #[test]
+    //         #[should_panic]
+    //         #[allow(unused_must_use)]
+    //         fn test_multiplication_($t)_failure_overflow_max() {
+    //             Money::max() * 100 as $t;
+    //         }
+    //
+    //         #[test]
+    //         #[should_panic]
+    //         #[allow(unused_must_use)]
+    //         fn test_multiplication_$t_failure_overflow_min() {
+    //             Money::min() * 100 as $t;
+    //         }
+    //     }
+    // }
 
     #[test]
     fn test_money_default() {
@@ -139,29 +254,29 @@ mod tests {
         Money::min() - Money(1);
     }
 
-    #[test]
-    fn test_multiplication_success() {
-        assert_eq!(Money(7) * Money(3), Money(21))
-    }
-
-    #[test]
-    #[should_panic]
-    #[allow(unused_must_use)]
-    fn test_multiplication_failure_overflow_max() {
-        Money::max() * Money(100);
-    }
-
-    #[test]
-    #[should_panic]
-    #[allow(unused_must_use)]
-    fn test_multiplication_failure_overflow_min() {
-        Money::min() * Money(100);
-    }
-
     // #[test]
-    // fn test_division() {
-    //
+    // fn test_multiplication_i32_success() {
+    //     assert_eq!(Money(7) * 3 as i32, Money(21))
     // }
+    //
+    // #[test]
+    // #[should_panic]
+    // #[allow(unused_must_use)]
+    // fn test_multiplication_i32_failure_overflow_max() {
+    //     Money::max() * 100 as i32;
+    // }
+    //
+    // #[test]
+    // #[should_panic]
+    // #[allow(unused_must_use)]
+    // fn test_multiplication_i32_failure_overflow_min() {
+    //     Money::min() * 100 as i32;
+    // }
+
+    #[test]
+    fn test_division() {
+        println!("{}", 87808 / 11);
+    }
 
     // SELECT m + '123' FROM money_data;
     // SELECT m + '123.45' FROM money_data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod parser;
 mod error;
 
 use error::Error;
-use std::ops::Add;
+use std::ops::{Add, Sub, Mul, Div};
 
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Money(Inner);
@@ -72,17 +72,22 @@ impl Default for Money {
     }
 }
 
-impl Add for Money {
-    type Output = Self;
+macro_rules! derive_trait_from_inner {
+    (impl $imp:ident, $method:ident) => {
+        impl $imp for Money {
+            type Output = Self;
 
-    // TODO: should this return a Result and do checked_add instead of panic?
-    fn add(self, rhs: Money) -> Self::Output {
-        Money(self.inner() + rhs.inner())
+            // TODO: should this return a Result and do checked_add instead of panic?
+            fn $method(self, rhs: Money) -> Self::Output {
+                Money(self.inner().$method(rhs.inner()))
+            }
+        }
     }
 }
 
-
-
+derive_trait_from_inner!(impl Add, add);
+derive_trait_from_inner!(impl Sub, sub);
+derive_trait_from_inner!(impl Mul, mul);
 
 #[cfg(test)]
 mod tests {
@@ -115,18 +120,46 @@ mod tests {
         Money::min() + Money(-1);
     }
 
-    // #[test]
-    // fn test_subtraction() {
-    //
-    // }
-    //
+    #[test]
+    fn test_subtraction_success() {
+        assert_eq!(Money(2) - Money(1), Money(1))
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused_must_use)]
+    fn test_subtraction_failure_overflow_max() {
+        Money::max() - Money(-1);
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused_must_use)]
+    fn test_subtraction_failure_overflow_min() {
+        Money::min() - Money(1);
+    }
+
+    #[test]
+    fn test_multiplication_success() {
+        assert_eq!(Money(7) * Money(3), Money(21))
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused_must_use)]
+    fn test_multiplication_failure_overflow_max() {
+        Money::max() * Money(100);
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused_must_use)]
+    fn test_multiplication_failure_overflow_min() {
+        Money::min() * Money(100);
+    }
+
     // #[test]
     // fn test_division() {
-    //
-    // }
-    //
-    // #[test]
-    // fn test_multiplication() {
     //
     // }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,25 @@ macro_rules! add_div_impl {
 derive_op_trait_from_inner!(impl Add, add);
 derive_op_trait_from_inner!(impl Sub, sub);
 add_mul_impl! { i64 i32 i16 i8 u32 u16 u8 f64 f32 }
-add_div_impl! { i64 i32 i16 i8 u32 u16 u8 f64 f32 }
+add_div_impl! { i64 i32 i16 i8 u32 u16 u8 }
+
+impl Div<f64> for Money {
+    type Output = Self;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        let inner = self.inner() as f64 / rhs;
+        Money(inner.round() as i64)
+    }
+}
+
+impl Div<f32> for Money {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        let inner = self.inner() as f32 / rhs;
+        Money(inner.round() as i64)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -405,5 +423,36 @@ mod tests {
     #[test]
     fn test_gt_inverse() {
         assert_eq!(Money(12300) > Money(12400), false)
+    }
+
+    // Rounding vs. Truncation in Division
+    #[test]
+    fn test_rounded_division_f64() {
+        assert_eq!(Money(87808) / 11.0 as f64, Money(7983))
+    }
+
+    #[test]
+    fn test_rounded_division_f32() {
+        assert_eq!(Money(87808) / 11.0 as f32, Money(7983))
+    }
+
+    #[test]
+    fn test_truncated_division_i64() {
+        assert_eq!(Money(87808) / 11 as i64, Money(7982))
+    }
+
+    #[test]
+    fn test_truncated_division_i32() {
+        assert_eq!(Money(87808) / 11 as i32, Money(7982))
+    }
+
+    #[test]
+    fn test_truncated_division_i16() {
+        assert_eq!(Money(87808) / 11 as i16, Money(7982))
+    }
+
+    #[test]
+    fn test_truncated_division_i8() {
+        assert_eq!(Money(87808) / 11 as i8, Money(7982))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod parser;
 
 use error::Error;
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Money(Inner);
@@ -105,9 +105,16 @@ macro_rules! add_mul_impl {
      )+)
 }
 
+macro_rules! add_div_impl {
+     ($($t:ty)+) => ($(
+         derive_trait_for_type! { impl Div with $t, div }
+     )+)
+}
+
 derive_trait_from_inner!(impl Add, add);
 derive_trait_from_inner!(impl Sub, sub);
 add_mul_impl! { i64 i32 i16 i8 u32 u16 u8 }
+add_div_impl! { i64 i32 i16 i8 u32 u16 u8 }
 
 #[cfg(test)]
 mod tests {
@@ -132,6 +139,20 @@ mod tests {
             #[allow(unused_must_use)]
             fn $of_min() {
                 Money::min() * 100 as $t;
+            }
+        };
+    }
+
+    macro_rules! gen_div_tests {
+        ($t:ty, $success:ident, $truncates:ident) => {
+            #[test]
+            fn $success() {
+                assert_eq!(Money(21) / 3 as $t, Money(7))
+            }
+
+            #[test]
+            fn $truncates() {
+                assert_eq!(Money(21) / 2 as $t, Money(10))
             }
         };
     }
@@ -185,28 +206,47 @@ mod tests {
         test_mul_fail_overflow_min_u8
     }
 
-    // macro_rules! test_mul_for_type {
-    //     ($t:ty $success:expr $overflow_max:expr $overflow_min:) => {
-    //         #[test]
-    //         fn test_multiplication_i32_success() {
-    //             assert_eq!(Money(7) * 3 as $t, Money(21))
-    //         }
-    //
-    //         #[test]
-    //         #[should_panic]
-    //         #[allow(unused_must_use)]
-    //         fn test_multiplication_($t)_failure_overflow_max() {
-    //             Money::max() * 100 as $t;
-    //         }
-    //
-    //         #[test]
-    //         #[should_panic]
-    //         #[allow(unused_must_use)]
-    //         fn test_multiplication_$t_failure_overflow_min() {
-    //             Money::min() * 100 as $t;
-    //         }
-    //     }
-    // }
+    gen_div_tests! {
+        i64,
+        test_div_success_i64,
+        test_div_truncates_i64
+    }
+
+    gen_div_tests! {
+        i32,
+        test_div_success_i32,
+        test_div_truncates_i32
+    }
+
+    gen_div_tests! {
+        i16,
+        test_div_success_i16,
+        test_div_truncates_i16
+    }
+
+    gen_div_tests! {
+        i8,
+        test_div_success_i8,
+        test_div_truncates_i8
+    }
+
+    gen_div_tests! {
+        u32,
+        test_div_success_u32,
+        test_div_truncates_u32
+    }
+
+    gen_div_tests! {
+        u16,
+        test_div_success_u16,
+        test_div_truncates_u16
+    }
+
+    gen_div_tests! {
+        u8,
+        test_div_success_u8,
+        test_div_truncates_u8
+    }
 
     #[test]
     fn test_money_default() {
@@ -252,30 +292,6 @@ mod tests {
     #[allow(unused_must_use)]
     fn test_subtraction_failure_overflow_min() {
         Money::min() - Money(1);
-    }
-
-    // #[test]
-    // fn test_multiplication_i32_success() {
-    //     assert_eq!(Money(7) * 3 as i32, Money(21))
-    // }
-    //
-    // #[test]
-    // #[should_panic]
-    // #[allow(unused_must_use)]
-    // fn test_multiplication_i32_failure_overflow_max() {
-    //     Money::max() * 100 as i32;
-    // }
-    //
-    // #[test]
-    // #[should_panic]
-    // #[allow(unused_must_use)]
-    // fn test_multiplication_i32_failure_overflow_min() {
-    //     Money::min() * 100 as i32;
-    // }
-
-    #[test]
-    fn test_division() {
-        println!("{}", 87808 / 11);
     }
 
     // SELECT m + '123' FROM money_data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,4 +455,25 @@ mod tests {
     fn test_truncated_division_i8() {
         assert_eq!(Money(87808) / 11 as i8, Money(7982))
     }
+
+    // Precision loss
+    #[test]
+    fn test_precision_loss_i64() {
+        assert_eq!(Money(9000000000000009900) / 10 as i64, Money(900000000000000990))
+    }
+
+    #[test]
+    fn test_precision_loss_i32() {
+        assert_eq!(Money(9000000000000009900) / 10 as i32, Money(900000000000000990))
+    }
+
+    #[test]
+    fn test_precision_loss_i16() {
+        assert_eq!(Money(9000000000000009900) / 10 as i16, Money(900000000000000990))
+    }
+
+    #[test]
+    fn test_precision_loss_i8() {
+        assert_eq!(Money(9000000000000009900) / 10 as i8, Money(900000000000000990))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl Default for Money {
     }
 }
 
-macro_rules! derive_trait_from_inner {
+macro_rules! derive_op_trait_from_inner {
     (impl $imp:ident, $method:ident) => {
         impl $imp for Money {
             type Output = Self;
@@ -121,8 +121,8 @@ macro_rules! add_div_impl {
     )+)
 }
 
-derive_trait_from_inner!(impl Add, add);
-derive_trait_from_inner!(impl Sub, sub);
+derive_op_trait_from_inner!(impl Add, add);
+derive_op_trait_from_inner!(impl Sub, sub);
 add_mul_impl! { i64 i32 i16 i8 u32 u16 u8 f64 f32 }
 add_div_impl! { i64 i32 i16 i8 u32 u16 u8 f64 f32 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,4 +345,65 @@ mod tests {
     fn test_money_div_f32() {
         assert_eq!(Money(12300) / 2 as f32, Money(6150))
     }
+
+    // Comparisons
+    #[test]
+    fn test_eq() {
+        assert_eq!(Money(12300), Money(12300))
+    }
+
+    #[test]
+    fn test_not_eq() {
+        assert_ne!(Money(12300), Money(12400))
+    }
+
+    #[test]
+    fn test_lt_eq() {
+        assert!(Money(12300) <= Money(12300))
+    }
+
+    #[test]
+    fn test_gt_eq() {
+        assert!(Money(12300) >= Money(12300))
+    }
+
+    #[test]
+    fn test_lt() {
+        assert!(Money(12300) < Money(12400))
+    }
+
+    #[test]
+    fn test_gt() {
+        assert!(Money(12300) > Money(12200))
+    }
+
+    #[test]
+    fn test_eq_inverse() {
+        assert_eq!(Money(12300) == Money(12301), false)
+    }
+
+    #[test]
+    fn test_not_eq_inverse() {
+        assert_eq!(Money(12300) != Money(12300), false)
+    }
+
+    #[test]
+    fn test_lt_eq_inverse() {
+        assert_eq!(Money(12300) <= Money(12299), false)
+    }
+
+    #[test]
+    fn test_gt_eq_inverse() {
+        assert_eq!(Money(12300) >= Money(12301), false)
+    }
+
+    #[test]
+    fn test_lt_inverse() {
+        assert_eq!(Money(12300) < Money(12200), false)
+    }
+
+    #[test]
+    fn test_gt_inverse() {
+        assert_eq!(Money(12300) > Money(12400), false)
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,4 @@
-use regex::{Regex, Match};
+use regex::{Match, Regex};
 
 pub use crate::error::Error;
 
@@ -38,7 +38,7 @@ impl Amount {
             .ok_or(Error::InvalidString)?;
 
         if caps.len() != 3 {
-            return Err(Error::InvalidString)
+            return Err(Error::InvalidString);
         }
 
         Ok(Amount {
@@ -68,19 +68,21 @@ impl Amount {
         let has_minus = Regex::new(r"-(.*)").unwrap();
         let has_paren = Regex::new(r"\((.*)\)").unwrap();
 
-        let m: Vec<Regex> = vec![has_minus, has_paren].into_iter()
+        let m: Vec<Regex> = vec![has_minus, has_paren]
+            .into_iter()
             .filter(|r| r.is_match(s))
             .collect();
 
         return match m.len() {
             0 => Self::positive(s),
             1 => {
-                let transformed = m.into_iter()
+                let transformed = m
+                    .into_iter()
                     .fold(s, |s, r| r.captures(s).unwrap().get(1).unwrap().as_str());
                 Self::negative(transformed)
-            },
-            _ => Err(Error::InvalidString)
-        }
+            }
+            _ => Err(Error::InvalidString),
+        };
     }
 
     fn to_money(&self) -> Result<Money, Error> {
@@ -93,14 +95,15 @@ impl Amount {
             -1
         } else {
             1
-        }
+        };
     }
 
     fn combine_dollars_and_cents(&self) -> Result<i64, Error> {
         let dollars = mk_int(&self.dollars)? * self.apply_sign();
         let cents = mk_rounded_cents(&self.cents)? * self.apply_sign();
 
-        dollars.checked_mul(100)
+        dollars
+            .checked_mul(100)
             .ok_or(Error::OutOfRange)?
             .checked_add(cents)
             .ok_or(Error::OutOfRange)
@@ -128,17 +131,16 @@ fn round_cents(s: &String) -> Result<i64, Error> {
 
 fn mk_int(s: &str) -> Result<i64, Error> {
     if s.is_empty() {
-        return Ok(0)
+        return Ok(0);
     }
 
-    str::parse::<i64>(&s)
-        .map_err(|e| {
-            // This is a janky workaround until ParseIntError.kind() is stable
-            match e.to_string().find("too large") {
-                Some(_) => Error::OutOfRange,
-                None => Error::ParseInt
-            }
-        })
+    str::parse::<i64>(&s).map_err(|e| {
+        // This is a janky workaround until ParseIntError.kind() is stable
+        match e.to_string().find("too large") {
+            Some(_) => Error::OutOfRange,
+            None => Error::ParseInt,
+        }
+    })
 }
 
 #[cfg(test)]
@@ -183,17 +185,26 @@ mod tests {
 
     #[test]
     fn test_valid_12345678901234567() {
-        assert_eq!(Money::parse_str("12345678901234567"), Ok(Money(1234567890123456700)))
+        assert_eq!(
+            Money::parse_str("12345678901234567"),
+            Ok(Money(1234567890123456700))
+        )
     }
 
     #[test]
     fn test_invalid_123456789012345678() {
-        assert_eq!(Money::parse_str("123456789012345678"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("123456789012345678"),
+            Err(Error::OutOfRange)
+        )
     }
 
     #[test]
     fn test_invalid_9223372036854775807() {
-        assert_eq!(Money::parse_str("9223372036854775807"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("9223372036854775807"),
+            Err(Error::OutOfRange)
+        )
     }
 
     #[test]
@@ -208,17 +219,26 @@ mod tests {
 
     #[test]
     fn test_valid_neg_12345678901234567() {
-        assert_eq!(Money::parse_str("-12345678901234567"), Ok(Money(-1234567890123456700)))
+        assert_eq!(
+            Money::parse_str("-12345678901234567"),
+            Ok(Money(-1234567890123456700))
+        )
     }
 
     #[test]
     fn test_invalid_neg_123456789012345678() {
-        assert_eq!(Money::parse_str("-123456789012345678"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("-123456789012345678"),
+            Err(Error::OutOfRange)
+        )
     }
 
     #[test]
     fn test_invalid_neg_9223372036854775808() {
-        assert_eq!(Money::parse_str("-9223372036854775808"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("-9223372036854775808"),
+            Err(Error::OutOfRange)
+        )
     }
 
     #[test]
@@ -243,16 +263,21 @@ mod tests {
 
     #[test]
     fn test_invalid_min() {
-        assert_eq!(Money::parse_str("-92233720368547758.085"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("-92233720368547758.085"),
+            Err(Error::OutOfRange)
+        )
     }
 
     #[test]
     fn test_invalid_max() {
-        assert_eq!(Money::parse_str("92233720368547758.075"), Err(Error::OutOfRange))
+        assert_eq!(
+            Money::parse_str("92233720368547758.075"),
+            Err(Error::OutOfRange)
+        )
     }
 
     // Money Ops
-
 
     // TODO: int parsing
     #[test]
@@ -277,12 +302,18 @@ mod tests {
 
     #[test]
     fn test_valid_12345678901234567_int() {
-        assert_eq!(Money::parse_int(12345678901234567), Money(12345678901234567))
+        assert_eq!(
+            Money::parse_int(12345678901234567),
+            Money(12345678901234567)
+        )
     }
 
     #[test]
     fn test_valid_neg_12345678901234567_int() {
-        assert_eq!(Money::parse_int(-12345678901234567), Money(-12345678901234567))
+        assert_eq!(
+            Money::parse_int(-12345678901234567),
+            Money(-12345678901234567)
+        )
     }
 
     #[test]


### PR DESCRIPTION
Implements Add, Div, Mul, Sub for the Money type.

Targets i8, i16, i32, i64, f32, and f64, but doesn't implement all the ops for each of the primitives. 

Test suite is based on the Postgres regression tests ([GitHub mirror](https://github.com/postgres/postgres/blob/master/src/test/regress/sql/money.sql)) and the expected outcomes ([GitHub mirror](https://github.com/postgres/postgres/blob/master/src/test/regress/expected/money.out)).